### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10
+#- package-ecosystem: npm
+#  directory: "/"
+#  schedule:
+#    interval: daily
+#    time: "11:00"
+#  open-pull-requests-limit: 10


### PR DESCRIPTION
DIsable Dependabot since it does not support yarn v2 yet.

See [here](https://github.com/dependabot/dependabot-core/issues/1297) for more information.